### PR TITLE
Updated numzerize import

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ pip install numerize
 numerize(number_to_numerize, decimal_places_to_round[optional])
 
 ```
->>> from numerize import numerize
+>>> from numerize.numerize import numerize
 >>> numerize(1234567.12)
 '1.23M'
 >>> numerize(12134.123, 3)


### PR DESCRIPTION
When attempting to use numerize a type error was raised due to numerize being a 'module' object. This edit changes the import and is one method for fixing this issue. The other would be to edit the function call (e.g numerize.numerize(123456)).