### PR TITLE
Update numerize.py

### DIFF
--- a/numerize/numerize.py
+++ b/numerize/numerize.py
@@ -1,34 +1,21 @@
-from decimal import Decimal
-
-def round_num(n, decimal=2):
-    n=Decimal(n)
-    return n.to_integral() if n == n.to_integral() else round(n.normalize(), decimal)
-
 def numerize(n, decimal=2):
-    #60 sufixes
-    sufixes = [ "", "K", "M", "B", "T", "Qa", "Qu", "S", "Oc", "No", 
-                "D", "Ud", "Dd", "Td", "Qt", "Qi", "Se", "Od", "Nd","V", 
-                "Uv", "Dv", "Tv", "Qv", "Qx", "Sx", "Ox", "Nx", "Tn", "Qa",
-                "Qu", "S", "Oc", "No", "D", "Ud", "Dd", "Td", "Qt", "Qi",
-                "Se", "Od", "Nd", "V", "Uv", "Dv", "Tv", "Qv", "Qx", "Sx",
-                "Ox", "Nx", "Tn", "x", "xx", "xxx", "X", "XX", "XXX", "END"] 
-    
-    sci_expr = [1e0, 1e3, 1e6, 1e9, 1e12, 1e15, 1e18, 1e21, 1e24, 1e27, 
-                1e30, 1e33, 1e36, 1e39, 1e42, 1e45, 1e48, 1e51, 1e54, 1e57, 
-                1e60, 1e63, 1e66, 1e69, 1e72, 1e75, 1e78, 1e81, 1e84, 1e87, 
-                1e90, 1e93, 1e96, 1e99, 1e102, 1e105, 1e108, 1e111, 1e114, 1e117, 
-                1e120, 1e123, 1e126, 1e129, 1e132, 1e135, 1e138, 1e141, 1e144, 1e147, 
-                1e150, 1e153, 1e156, 1e159, 1e162, 1e165, 1e168, 1e171, 1e174, 1e177]
-    minus_buff = n
-    n=abs(n)
-    for x in range(len(sci_expr)):
-        try:
-            if n >= sci_expr[x] and n < sci_expr[x+1]:
-                sufix = sufixes[x]
-                if n >= 1e3:
-                    num = str(round_num(n/sci_expr[x], decimal))
-                else:
-                    num = str(n)
-                return num + sufix if minus_buff > 0 else "-" + num + sufix
-        except IndexError:
-            print("You've reached the end")
+    sufixes = ["", "K", "M", "B", "T", "Qa", "Qu", "S", "Oc", "No",
+               "D", "Ud", "Dd", "Td", "Qt", "Qi", "Se", "Od", "Nd", "V",
+               "Uv", "Dv", "Tv", "Qv", "Qx", "Sx", "Ox", "Nx", "Tn", "Qa",
+               "Qu", "S", "Oc", "No", "D", "Ud", "Dd", "Td", "Qt", "Qi",
+               "Se", "Od", "Nd", "V", "Uv", "Dv", "Tv", "Qv", "Qx", "Sx",
+               "Ox", "Nx", "Tn", "x", "xx", "xxx", "X", "XX", "XXX", "END"]
+
+    sci_expr = [10 ** (3 * i) for i in range(len(sufixes))]
+
+    abs_n = abs(n)
+    for i, expr in enumerate(sci_expr[::-1]):
+        if abs_n >= expr:
+            num = abs_n / expr
+            sufix = sufixes[len(sci_expr) - 1 - i]
+            formatted_num = '{:.{}f}'.format(num, decimal).rstrip('0').rstrip('.')
+            return formatted_num + sufix if n > 0 else '-' + formatted_num + sufix
+
+    # If n is smaller than the smallest sci_expr, return n as a string with the specified number of decimal places
+    formatted_num = '{:.{}f}'.format(abs_n, decimal).rstrip('0').rstrip('.')
+    return formatted_num if n > 0 else '-' + formatted_num


### PR DESCRIPTION
    sci_expr is now generated as a list comprehension.
    The round_num() function is no longer used. Instead, we use Python's built-in string formatting ({:.{}f}) to format the number to the specified number of decimal places.
    The loop now iterates in reverse over sci_expr so that we can use len(sci_expr) - 1 - i to index into sufixes.
    We format the number as a string and strip any trailing zeros and decimal points.
    We now return the absolute value of n formatted as a string if it is smaller than the smallest sci_expr.